### PR TITLE
fix: Use bigger size of QR codes online

### DIFF
--- a/src/lib/QrcodeChunks/constants.ts
+++ b/src/lib/QrcodeChunks/constants.ts
@@ -2,9 +2,9 @@
 // const QR_CODE_MAX_BYTE_LENGTH = 2953;
 
 // What the library currently allows:
-// const QR_CODE_MAX_BYTE_LENGTH = 2332;
+const QR_CODE_MAX_BYTE_LENGTH = 2332;
 
 // For testing purposes:
-const QR_CODE_MAX_BYTE_LENGTH = 15;
+// const QR_CODE_MAX_BYTE_LENGTH = 15;
 
 export const maxChunkLength: number = QR_CODE_MAX_BYTE_LENGTH - 'MQR00.99.'.length;


### PR DESCRIPTION
Signed-off-by: Joern Bernhardt <joern.bernhardt@compose.us>