### PR TITLE
feat: Add QR code with link to read page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This web-app lets you create QR codes for longer texts that you can then scan fr
 It will not send any data to the server, the app only manages the creation of QR codes by splitting it into chunks. The same app can be used to retrieve these QR codes and put the information back together. As soon as you have opened the web-page, it will work without using the internet.
 
 Workflow:
+
 1. Go to the Magic QR Code Data Transfer page on the device where you want to send something (the sender). 👩‍💻
 2. Input all the text you want to send to the receiving device. ⌨️
 3. Go to the Magic QR Code Data Transfer page on the device that you want to get the data to (the receiver). 👨‍💻

--- a/src/lib/ShowQrcodeToReader/ShowQrcodeToReader.svelte
+++ b/src/lib/ShowQrcodeToReader/ShowQrcodeToReader.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import { page } from '$app/stores';
+	import Qrcode from '$lib/Qrcode/Qrcode.svelte';
+
+	const path = `${base}/read`;
+	const readerUrl = `${$page.url.origin}${path}`;
+</script>
+
+<figure>
+	<Qrcode value={readerUrl} />
+	<figcaption>You can use the above QR code to navigate to {readerUrl} on your phone.</figcaption>
+</figure>
+
+<style>
+	figure {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		gap: 1em;
+		margin: 0;
+	}
+
+	figcaption {
+		margin: 0;
+		text-align: center;
+	}
+</style>

--- a/src/routes/create.svelte
+++ b/src/routes/create.svelte
@@ -2,6 +2,7 @@
 	import PageWithNavigation from '$lib/PageWithNavigation/PageWithNavigation.svelte';
 	import Qrcode from '$lib/Qrcode/Qrcode.svelte';
 	import QrcodeChunks from '$lib/QrcodeChunks/QrcodeChunks.svelte';
+	import ShowQrcodeToReader from '$lib/ShowQrcodeToReader/ShowQrcodeToReader.svelte';
 	import Textarea from '$lib/Textarea/Textarea.svelte';
 
 	let data: string;
@@ -12,29 +13,35 @@
 	<h1>Create magic QR codes</h1>
 	<p>This is where we can create QR codes.</p>
 
+	<ShowQrcodeToReader />
+
 	<p>Put your data in here:</p>
 	<Textarea bind:value={data} />
 
 	{#if error}
-		<p>Error!</p>
-		<p>{error}</p>
-	{:else}
-		<p>The chunks are:</p>
-		<QrcodeChunks {data} let:chunks>
-			<div slot="ERROR_MAX_CHUNK_LENGTH_EXCEEDED" let:maxChunkLength>
-				We don't want to create more than 100 QR codes for this (max byte length = {maxChunkLength *
-					100})
-			</div>
+		<section>
+			<p>Error!</p>
+			<p>{error}</p>
+		</section>
+	{:else if data !== ''}
+		<section>
+			<p>The chunks are:</p>
+			<QrcodeChunks {data} let:chunks>
+				<div slot="ERROR_MAX_CHUNK_LENGTH_EXCEEDED" let:maxChunkLength>
+					We don't want to create more than 100 QR codes for this (max byte length = {maxChunkLength *
+						100})
+				</div>
 
-			<ul class="qrcodes">
-				{#each chunks as chunk, index}
-					<li class="qrcode">
-						<Qrcode value={chunk} />
-						<div>{index + 1}</div>
-					</li>
-				{/each}
-			</ul>
-		</QrcodeChunks>
+				<ul class="qrcodes">
+					{#each chunks as chunk, index}
+						<li class="qrcode">
+							<Qrcode value={chunk} />
+							<div>{index + 1}</div>
+						</li>
+					{/each}
+				</ul>
+			</QrcodeChunks>
+		</section>
 	{/if}
 </PageWithNavigation>
 


### PR DESCRIPTION
It's good to have a QR code to scan to land on the `/read` page for a reader. This hopefully becomes obsolete with the implementation of #1, but for now it would be good to let the device with the camera be able to at least open the reader page.